### PR TITLE
ajout gitignore complet DevOps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,34 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# ========================
+# DevOps
+# ========================
+
+# Docker
+*.env.docker
+.docker/
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+.terraform.lock.hcl
+
+# Ansible
+*.retry
+inventory/
+
+# Kubernetes
+kubeconfig
+*.kubeconfig
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/


### PR DESCRIPTION
## 📋 Description
Ajout des sections DevOps au .gitignore

## ✅ Changements
- Ajout section Docker
- Ajout section Terraform
- Ajout section Ansible
- Ajout section Kubernetes
- Ajout section IDE et OS

## 🧪 Tests
- Vérification manuelle du .gitignore